### PR TITLE
Remove `callback` parameter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var pangunode = require('pangunode');
 
-hexo.extend.filter.register('after_post_render', function(data, callback){
+hexo.extend.filter.register('after_post_render', function(data) {
   data.content = pangunode(data.content);
-  callback(null, data);
 });
+


### PR DESCRIPTION
We do not need `callback` parameter because hexo changed to `promise` for async filters.
