### PR TITLE
fix: only add space to text, not inside markdown links

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const remark = require('remark');
 const pangu = require('remark-pangu');
 
-hexo.extend.filter.register('after_post_render', data => {
+hexo.extend.filter.register('before_post_render', data => {
   remark().use(pangu).process(data.title, (err, file) => {
     data.title = String(file);
   });
@@ -9,4 +9,6 @@ hexo.extend.filter.register('after_post_render', data => {
   remark().use(pangu).process(data.content, (err, file) => {
     data.content = String(file);
   });
+
+  return data;
 });

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
-var pangunode = require('pangunode');
+const remark = require('remark');
+const pangu = require('remark-pangu');
 
-hexo.extend.filter.register('after_post_render', function(data) {
-  data.title = pangunode(data.title);
-  data.content = pangunode(data.content);
+hexo.extend.filter.register('after_post_render', data => {
+  remark().use(pangu).process(data.title, (err, file) => {
+    data.title = String(file);
+  });
+
+  remark().use(pangu).process(data.content, (err, file) => {
+    data.content = String(file);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "remark": "^11.0.1",
+    "remark-frontmatter": "^1.3.2",
     "remark-pangu": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "pangunode": "^0.1.0"
+    "remark": "^11.0.1",
+    "remark-pangu": "^1.0.1"
   }
 }


### PR DESCRIPTION
An attempt to address #4, #5 

### How to test
```diff
package.json
- "hexo-filter-auto-spacing": "^0.2.1"
+ "hexo-filter-auto-spacing": "curbengh/hexo-filter-auto-spacing#pangu"
```
