### PR TITLE
fix: only add space to text, not links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](https://badge.fury.io/js/hexo-filter-auto-spacing.svg)](http://badge.fury.io/js/hexo-filter-auto-spacing)
 
-Add spaces between CJK characters and western characters.
+Add a space between Chinese and Western characters.
 
 ## Install
 
@@ -12,3 +12,12 @@ $ npm install hexo-filter-auto-spacing --save
 
 - Hexo 3: >= 0.2
 - Hexo 2: 0.1.x
+
+## Options
+``` yaml
+spacing:
+  tags: ['p', 'h1', 'h2', 'h3', 'title', 'a']
+```
+
+- **tags**: Specify [HTML tags/elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) to be processed.
+  + To process the text in `<p>This is a中文text</p>`, specify `'p'`.

--- a/index.js
+++ b/index.js
@@ -27,10 +27,6 @@ hexo.extend.filter.register('after_render:html', str => {
     words.push($(element).text());
   });
 
-  $('span').each((index, element) => {
-    words.push($(element).text());
-  });
-
   words = Array.from(new Set(words));
 
   for (let index in words) {

--- a/index.js
+++ b/index.js
@@ -2,38 +2,8 @@
 
 /* global hexo */
 
-const pangu = require('pangu');
-const cheerio = require('cheerio');
+hexo.config.spacing = Object.assign({
+  tags: ['p', 'h1', 'h2', 'h3']
+}, hexo.config.spacing);
 
-hexo.extend.filter.register('after_render:html', str => {
-  let $ = cheerio.load(str, { decodeEntities: false });
-
-  let result = $.html();
-  let words = [];
-
-  $('p').each((index, element) => {
-    words.push($(element).text());
-  });
-
-  $('h1').each((index, element) => {
-    words.push($(element).text());
-  });
-
-  $('h2').each((index, element) => {
-    words.push($(element).text());
-  });
-
-  $('h3').each((index, element) => {
-    words.push($(element).text());
-  });
-
-  words = Array.from(new Set(words));
-
-  for (let index in words) {
-    let word = words[index];
-
-    result = result.replace(word, pangu.spacing(word));
-  }
-
-  return result;
-});
+hexo.extend.filter.register('after_render:html', require('./lib/spacing'));

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 /* global hexo */
 
 hexo.config.spacing = Object.assign({
-  tags: ['p', 'h1', 'h2', 'h3']
+  tags: ['p', 'h1', 'h2', 'h3', 'title', 'a']
 }, hexo.config.spacing);
 
 hexo.extend.filter.register('after_render:html', require('./lib/spacing'));

--- a/index.js
+++ b/index.js
@@ -1,6 +1,43 @@
-var pangunode = require('pangunode');
+'use strict';
 
-hexo.extend.filter.register('after_post_render', function(data) {
-  data.title = pangunode(data.title);
-  data.content = pangunode(data.content);
+/* global hexo */
+
+const pangu = require('pangu');
+const cheerio = require('cheerio');
+
+hexo.extend.filter.register('after_render:html', str => {
+  let $ = cheerio.load(str, { decodeEntities: false });
+
+  let result = $.html();
+  let words = [];
+
+  $('p').each((index, element) => {
+    words.push($(element).text());
+  });
+
+  $('h1').each((index, element) => {
+    words.push($(element).text());
+  });
+
+  $('h2').each((index, element) => {
+    words.push($(element).text());
+  });
+
+  $('h3').each((index, element) => {
+    words.push($(element).text());
+  });
+
+  $('span').each((index, element) => {
+    words.push($(element).text());
+  });
+
+  words = Array.from(new Set(words));
+
+  for (let index in words) {
+    let word = words[index];
+
+    result = result.replace(word, pangu.spacing(word));
+  }
+
+  return result;
 });

--- a/lib/spacing.js
+++ b/lib/spacing.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const pangu = require('pangu');
+const cheerio = require('cheerio');
+
+module.exports = function(str, data) {
+  const options = this.config.spacing;
+  const tags = options.tags;
+  let $ = cheerio.load(str, { decodeEntities: false });
+  let result = $.html();
+  let words = [];
+
+  tags.forEach(tag => {
+    $(tag).each((index, element) => {
+      words.push($(element).text().trim());
+    });
+  });
+
+  words = Array.from(new Set(words));
+
+  words.forEach(word => {
+    if (word) {
+      result = result.replace(word, pangu.spacing(word));
+    }
+  });
+
+  return result;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "hexo-filter-auto-spacing",
+  "version": "0.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "pangu": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pangu/-/pangu-4.0.7.tgz",
+      "integrity": "sha512-weZKJIwwy5gjt4STGVUH9bix3BGk7wZ2ahtIypwe3e/mllsrIZIvtfLx1dPX56GcpZFOCFKmeqI1qVuB9enRzA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "pangunode": "^0.1.0"
+    "cheerio": "0.22.0",
+    "pangu": "^4.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.2.1",
   "description": "Add spaces between CJK characters and western characters.",
   "main": "index.js",
+  "directories": {
+    "lib": "./lib"
+  },
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "repository": "hexojs/hexo-filter-auto-spacing",
   "bugs": {
     "url": "https://github.com/hexojs/hexo-filter-auto-spacing/issues"


### PR DESCRIPTION
This is alternative approach to #8, in an attempt to address #4, #5.

This approach assumes each sentence is unique and only modifies text in limited html tags, i.e. `<p>` and `<h1-3>`

### How to test
```diff
package.json
- "hexo-filter-auto-spacing": "^0.2.1"
+ "hexo-filter-auto-spacing": "curbengh/hexo-filter-auto-spacing#cheerio"
```

Demo: 
https://github.com/curbengh/hexo-testing/blob/master/source/_posts/test-pangu.md
https://curbengh.github.io/hexo-testing/2018/10/05/test-pangu/

cc: @NanerLee, @geekrainy, @LeoJhonSong